### PR TITLE
CI Testing PR: Add unit test to ensure calling GET after DELETE returns 404

### DIFF
--- a/ci_lab/tests/test_counter.py
+++ b/ci_lab/tests/test_counter.py
@@ -281,3 +281,23 @@ class TestCounterEndpoints:
         assert response.status_code == HTTPStatus.BAD_REQUEST
 
         # TODO: Add an assertion to verify the error message specifically says 'Invalid counter name'S
+
+    # ===========================
+    # Test: Call GET after DELETE returns 404
+    # Author: Tri Tran
+    # ===========================
+    def test_get_after_delete_returns_404(self, client):
+        """It should return 404 when retrieving a deleted counter"""
+        client.post('/counters/to_delete')
+
+        # Delete the counter
+        delete_resp = client.delete('/counters/to_delete')
+
+        # Assert the delete response is successful
+        assert delete_resp.status_code == HTTPStatus.NO_CONTENT
+
+        # Try to retrieve the deleted counter
+        get_resp = client.get('/counters/to_delete')
+
+        # Assert that the get response returns 404
+        assert get_resp.status_code == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
## Summary

This PR adds a new unit test to validate lifecycle behavior of counters:
after deleting a counter, attempting to retrieve it should return 404.

---

## New Test Added

```python
# ===========================
# Test: Call GET after DELETE returns 404
# Author: Tri Tran
# ===========================
def test_get_after_delete_returns_404(self, client):
    """It should return 404 when retrieving a deleted counter"""
    client.post('/counters/to_delete')

    # Delete the counter
    delete_resp = client.delete('/counters/to_delete')

    # Assert the delete response is successful
    assert delete_resp.status_code == HTTPStatus.NO_CONTENT

    # Try to retrieve the deleted counter
    get_resp = client.get('/counters/to_delete')

    # Assert that the get response returns 404
    assert get_resp.status_code == HTTPStatus.NOT_FOUND
```

---

## Behavior Covered

This test validates proper lifecycle handling of counters:
- A counter can be deleted successfully.
- After deletion, it should no longer be retrievable.
- The API must return HTTP 404 for deleted resources.

This ensures correct state management and RESTful behavior.

---

## Coverage Comparison

### Before
<img width="353" height="369" alt="image" src="https://github.com/user-attachments/assets/f5cd06e1-63bb-4c85-ba4f-df4d475d4fb1" />

### After
<img width="353" height="374" alt="image" src="https://github.com/user-attachments/assets/1968b028-a1c7-4847-8dfe-409ee70abe4b" />

This test improves behavioral validation. While overall percentage coverage does not increase, it strengthens confidence in state transition logic.

---

## CI Evidence
<img width="1464" height="847" alt="image" src="https://github.com/user-attachments/assets/d35b847d-3431-4872-ba79-9a1f4a56bf01" />
