### PR TITLE
CI Debugging PR: Intentional break and fix failing test

### DIFF
--- a/ci_lab/tests/test_counter.py
+++ b/ci_lab/tests/test_counter.py
@@ -314,3 +314,12 @@ class TestCounterEndpoints:
 
         assert response.status_code == HTTPStatus.NOT_FOUND
         assert response.get_json() == {"error": "No counters available"}
+
+    # ===========================
+    # Test: CI Debug Intentional Failure
+    # Author: Tri Tran
+    # Description: Intentionally fails to demonstrate CI debugging workflow.
+    # ===========================
+    def test_intentional_failure(self, client):
+        """This test is designed to fail to demonstrate CI debugging."""
+        assert False, "This is an intentional failure for CI debugging demonstration."

--- a/ci_lab/tests/test_counter.py
+++ b/ci_lab/tests/test_counter.py
@@ -322,4 +322,7 @@ class TestCounterEndpoints:
     # ===========================
     def test_intentional_failure(self, client):
         """This test is designed to fail to demonstrate CI debugging."""
-        assert False, "This is an intentional failure for CI debugging demonstration."
+        # assert False, "This is an intentional failure for CI debugging demonstration."
+
+        # uncomment the above line to see the failure in CI
+        assert True # otherwise, this test will pass and not demonstrate the failure scenario.


### PR DESCRIPTION
Closes #10 

## What I did (Intentional Failure)

To simulate a CI failure scenario, I added an intentionally failing test:

```python
def test_intentional_failure(self, client):
    """This test is designed to fail to demonstrate CI debugging."""
    assert False, "This is an intentional failure for CI debugging demonstration."
```

This caused the GitHub Actions workflow to fail across all Python versions in the matrix.

---

## Failing CI Log Snippet

```
=================================== FAILURES ===================================
________________ TestCounterEndpoints.test_intentional_failure _________________

self = <tests.test_counter.TestCounterEndpoints object at 0x7f46af824b50>
client = <FlaskClient <Flask 'src.counter'>>

    def test_intentional_failure(self, client):
        """This test is designed to fail to demonstrate CI debugging."""
>       assert False, "This is an intentional failure for CI debugging demonstration."
E       AssertionError: This is an intentional failure for CI debugging demonstration.
E       assert False

tests/test_counter.py:325: AssertionError
```

---

## Root Cause
The test explicitly contained ``assert False``, which guarantees failure during test execution.

---

## Fix Applied
I modified the test to pass by removing the failing assertion:

```python
def test_intentional_failure(self, client):
    """This test is designed to fail to demonstrate CI debugging."""
    # assert False, "This is an intentional failure for CI debugging demonstration."

    # uncomment the above line to see the failure in CI
    assert True # otherwise, this test will pass and not demonstrate the failure scenario.
```

After pushing the fix, the CI workflow re-ran successfully across all Python versions (3.9, 3.10, 3.11).

---

## CI Evidence

[Failed run](https://github.com/trant98/Group-3-public/actions/runs/22081807296)
[Successful run](https://github.com/trant98/Group-3-public/actions/runs/22082094708)
